### PR TITLE
Fix mismatched dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.12.0</version>
+            <version>4.11.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Someone generated all the files with a different version than the one specified in the project metadata. Now fixed :)