### PR TITLE
Do not link function parameters to original variables

### DIFF
--- a/src/main/java/dk/aau/p4/abaaja/Lib/Interpreter/Interpreter.java
+++ b/src/main/java/dk/aau/p4/abaaja/Lib/Interpreter/Interpreter.java
@@ -320,7 +320,7 @@ public class Interpreter implements INodeVisitor {
 
                 int i = 0;
                 for(ExpNode actualParam : node.get_paramExps()){
-                    Symbol paramSymbol = resolve(actualParam);
+                    Symbol paramSymbol = resolve(actualParam).clone();
                     paramSymbol.set_name(symbol.get_formalParams().get(i).get_id());
                     symbolTable.insertSymbol(paramSymbol);
                     i++;

--- a/src/test/java/dk/aau/p4/abaaja/InterpreterTests/InterpreterTests.java
+++ b/src/test/java/dk/aau/p4/abaaja/InterpreterTests/InterpreterTests.java
@@ -1094,6 +1094,7 @@ public class InterpreterTests {
     public Object[][] lateAssignNoAssignTestData_number() {
         return new Object[][] {
                 {"variable test: NUMBER; variable other: NUMBER; other = 4; test = other; other = 2;", 4.0},
+                {"variable test: NUMBER; test = 4; to run(other: NUMBER): NOTHING { other++; } run(test);", 4.0},
         };
     }
     @Test(dataProvider = "lateAssignNoAssignTestData_number")


### PR DESCRIPTION
Currently, reassigning a parameter from a function call, will also reassign the variable that was passed to that function. Big yikes 😇