### PR TITLE
Reverse the printed order of problems

### DIFF
--- a/src/main/java/dk/aau/p4/abaaja/MCTLFormatter.java
+++ b/src/main/java/dk/aau/p4/abaaja/MCTLFormatter.java
@@ -19,6 +19,8 @@ import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 
+import java.util.ListIterator;
+
 public class MCTLFormatter {
 
     IGameBridge gameBridge;
@@ -43,8 +45,9 @@ public class MCTLFormatter {
             concreteNode.accept(new PrettyPrintVisitor(stringSink));
 
             // Prints parse errors
-            for (Problem problem : problemCollection.getProblems()) {
-                gameBridge.print(problem.getMessage());
+            ListIterator<Problem> problemIterator = problemCollection.getProblems().listIterator(problemCollection.getProblems().size());
+            while (problemIterator.hasPrevious()) {
+                gameBridge.print(problemIterator.previous().getMessage());
             }
         }
         gameBridge.internal_terminate();

--- a/src/main/java/dk/aau/p4/abaaja/MCTLInterpreter.java
+++ b/src/main/java/dk/aau/p4/abaaja/MCTLInterpreter.java
@@ -19,6 +19,8 @@ import dk.aau.p4.abaaja.Lib.ProblemHandling.ProblemCollection;
 import dk.aau.p4.abaaja.Lib.ProblemHandling.Listeners.LexerProblemListener;
 import dk.aau.p4.abaaja.Lib.ProblemHandling.Listeners.ParserProblemListener;
 
+import java.util.ListIterator;
+
 public class MCTLInterpreter {
 
     IGameBridge gameBridge;
@@ -45,8 +47,9 @@ public class MCTLInterpreter {
         }
 
         // Prints Errors and Warnings
-        for (Problem problem : problemCollection.getProblems()) {
-            gameBridge.print(problem.getMessage());
+        ListIterator<Problem> problemIterator = problemCollection.getProblems().listIterator(problemCollection.getProblems().size());
+        while (problemIterator.hasPrevious()) {
+            gameBridge.print(problemIterator.previous().getMessage());
         }
 
         gameBridge.internal_terminate();


### PR DESCRIPTION
In cases where there are multiple problems, the first encountered problem is usually the real issue, and the following problems are just consequences of the first error.

Unfortunately, the minecraft chat makes it hard/impossible to read the first encountered problem when other problems are printed afterwards. This is also confusing for new users who will probably read the last encountered problem first, and focus on fixing that.

I propose reversing the printed order. This ensures the user can read the first error, and makes it much more likely that they will notice and fix that one first.